### PR TITLE
Added resetActions to method closeDevice

### DIFF
--- a/Modality/Classes/MKtl/MKtl.sc
+++ b/Modality/Classes/MKtl/MKtl.sc
@@ -673,6 +673,7 @@ MKtl { // abstract class
 
 	closeDevice {
 		if ( device.isNil ){ ^this };
+		this.resetActions;
 		device.closeDevice;
 		device = nil;
 	}


### PR DESCRIPTION
Calling .free or .closeDevice on a MKtl will now reset actions.
